### PR TITLE
[Bugfix] Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1
+FROM fluent/fluentd-kubernetes-daemonset:v1.18-debian-logzio-amd64-1
 
 USER root
 WORKDIR /fluentd

--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ If you still don't see your logs,
 see [log shipping troubleshooting](https://docs.logz.io/user-guide/log-shipping/log-shipping-troubleshooting.html).
 
 ### Changelog:
+- 0.1.0: Update fluet base image to `fluent/fluentd-kubernetes-daemonset:v1.18-debian-logzio-amd64-1`
 - 0.0.1: Initial release.


### PR DESCRIPTION
## Description 

- Update fluet base image to `fluent/fluentd-kubernetes-daemonset:v1.18-debian-logzio-amd64-1`

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
